### PR TITLE
Only build/make if git clone task reported a change

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,7 @@
     repo={{silversearcher_ag_repo}}
     dest={{silversearcher_ag_sources_path}}
     update=yes
+  register: gitrepo
 
 
 - name: compile and install
@@ -13,3 +14,4 @@
   with_items:
     - "./build.sh"
     - "make install"
+  when: gitrepo.changed


### PR DESCRIPTION
Hey, thanks for creating this role! I am using it for my local development setup and it works perfectly fine.

I noticed that `build.sh` and `make` are always executed even if the clone did not contain any changes.
With this commit, `./build.sh` and `make install` will only be executed if a new clone contains changes :sparkles: